### PR TITLE
Trim for new line char "\n" from "version"

### DIFF
--- a/plugins/nexus-repository-cocoapods/src/main/java/org/sonatype/nexus/repository/cocoapods/internal/proxy/SpecTransformer.java
+++ b/plugins/nexus-repository-cocoapods/src/main/java/org/sonatype/nexus/repository/cocoapods/internal/proxy/SpecTransformer.java
@@ -82,7 +82,7 @@ public class SpecTransformer
     }
 
     final String name = jsonSpec.get(POD_NAME_FIELD).asText();
-    final String version = jsonSpec.get(POD_VERSION_FIELD).asText();
+    final String version = jsonSpec.get(POD_VERSION_FIELD).asText().trim();
 
     URI sourceUri = buidProxiedUri(jsonSpec.get(SOURCE_NODE_NAME), name, version, repoUri);
 


### PR DESCRIPTION
New line char causes an error over NXRM. Removed new line "\n" from version. 
Auto-Closed PR: https://github.com/CocoaPods/Specs/pull/14429

CDN: *****-repository-cocoapods-proxy URL couldn't be downloaded: https://*******/repository/cocoapods-proxy/Specs/9/4/5/RealmSwift/0.92.1/RealmSwift.podspec.json Response: 500

javax.servlet.ServletException: java.lang.IllegalArgumentException: Illegal character in path at index 22: pods/RealmSwift/0.92.1
/https/api.github.com/repos/realm/realm-cocoa/tarball/v0.92.1.tar.gz